### PR TITLE
Filter nan values from depth

### DIFF
--- a/utils/theoretical_profiles.py
+++ b/utils/theoretical_profiles.py
@@ -311,7 +311,7 @@ def create_theoretical_profiles(legger_db_filepath, gradient_norm, bv):
 
     # additional: set max on 1.2 times th maximal depth within the specific category
     cursor.execute(
-        "Select categorieoppwaterlichaam, max(diepte) as max_diepte from hydroobjects_kenmerken GROUP BY categorieoppwaterlichaam ORDER BY categorieoppwaterlichaam ")
+        "SELECT categorieoppwaterlichaam, max(diepte) as max_diepte FROM hydroobjects_kenmerken WHERE diepte > 0 AND diepte < 10 GROUP BY categorieoppwaterlichaam ORDER BY categorieoppwaterlichaam ")
     categories_max_depth = cursor.fetchall()
 
     last_category = 15


### PR DESCRIPTION
For castricum the DAMO database contains some nan values for depth. This makes the maximum nan and stops the entire function from working.